### PR TITLE
Fix/product,genre

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,16 +18,7 @@
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
 
-header {
-  width: auto;
-  height: 180px;
-  background-color: rgba( 135, 135, 135, 0.55 );
-  padding-top: 50px;
-  padding-left: 80px;
-  padding-right: 100px;
-  color: black;
-  font-family: 'Corben', cursive;
-}
+
 
 footer {
   width: auto;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,7 +18,16 @@
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
 
-
+header {
+  width: auto;
+  height: 180px;
+  background-color: rgba( 135, 135, 135, 0.55 );
+  padding-top: 50px;
+  padding-left: 80px;
+  padding-right: 100px;
+  color: black;
+  font-family: 'Corben', cursive;
+}
 
 footer {
   width: auto;

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -1,10 +1,10 @@
 class GenresController < ApplicationController
 
 	def show
-		@genres = Genre.all
+		@genres = Genre.where(is_active: true)
 		@genre = Genre.find(params[:id])
-		@products = @genre.products.page(params[:page]).per(8)
-		@product = @genre.products.all
+		@products = @genre.products.where(is_active: true).page(params[:page]).per(8)
+		@product = @genre.products.where(is_active: true)
 	end
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,15 +1,15 @@
 class ProductsController < ApplicationController
 
   def index
-  	@product = Product.all
-  	@products = Product.page(params[:page]).per(8)
-  	@genres = Genre.all
+    @product = Product.includes(:genre).where(genres: {is_active: true}).where(is_active: true)
+  	@products = Product.includes(:genre).where(genres: {is_active: true}).where(is_active: true).page(params[:page]).per(8)
+  	@genres = Genre.where(is_active: true)
   end
 
   def show
   	@product = Product.find(params[:id])
     @cart_item = CartItem.new
-    @genres = Genre.all
+    @genres = Genre.where(is_active: true)
   end
 
 end

--- a/app/views/admins/products/new.html.erb
+++ b/app/views/admins/products/new.html.erb
@@ -6,7 +6,7 @@
 			<%= form_for(@product, url: admins_products_path) do |f| %>
 			<div class="col-xs-5">
 				<div class="product-img">
-				<%= attachment_image_tag @product, :image, :size => '300x250', id: "file-preview",fallback: "no_image.png",size:'300x250' %>
+				<%# attachment_image_tag @product, :image, :size => '300x250', id: "file-preview",fallback: "no_image.png",size:'300x250' %>
 			    </div>
 				<div class="product-new-form">
 					<%= f.attachment_field :image, id: "product_img" %>

--- a/app/views/admins/products/new.html.erb
+++ b/app/views/admins/products/new.html.erb
@@ -1,12 +1,12 @@
-<div class="container">
-	<div class="row">
-		<div style="width: 100%;height: 150px;"></div>
-		<div style="height: 483px">
-			<h3 style="width:180px;height: 50px;background-color: rgba( 135, 135, 135, 0.55 );border-radius: 15px;text-align: center;padding-top: 12px;font-weight: bold;">商品新規登録</h3><br>
-			<%= form_for(@product, url: admins_products_path) do |f| %>
+<div class="row">
+	<div style="width: 100%;height: 150px;"></div>
+	<div style="height: 483px">
+		<h3 style="width:180px;height: 50px;background-color: rgba( 135, 135, 135, 0.55 );border-radius: 15px;text-align: center;padding-top: 12px;font-weight: bold;">商品新規登録</h3><br>
+
+		<%= form_for(@product, url: admins_products_path) do |f| %>
 			<div class="col-xs-5">
 				<div class="product-img">
-				<%# attachment_image_tag @product, :image, :size => '300x250', id: "file-preview",fallback: "no_image.png",size:'300x250' %>
+				<%= attachment_image_tag @product, :image, :size => '300x250', id: "file-preview",fallback: "no_image.png",size:'300x250' %>
 			    </div>
 				<div class="product-new-form">
 					<%= f.attachment_field :image, id: "product_img" %>
@@ -19,14 +19,14 @@
 	        			if (input.files && input.files[0]) {
 	        			var reader = new FileReader();
 	        			reader.onload = function (e) {
-	    			$('#file-preview').attr('src', e.target.result);
-	        		}
-	        		reader.readAsDataURL(input.files[0]);
-	        		}
-	    		}
+	    					$('#file-preview').attr('src', e.target.result);
+	        			}
+	        			reader.readAsDataURL(input.files[0]);
+	        			}
+	    			}
 	    		$("#product_img").change(function(){
 	        		readURL(this);
-	    		});
+	    			});
 	  			});
 			</script>
 			
@@ -57,10 +57,10 @@
 		    		</tbody>
 		    	</table>
 		    </div>
-	    </div>
-	    <div class="col-xs-2" style="padding-bottom: 100px;padding-left: 1000px;">
-	    	<%= f.submit '新規登録', class: "btn btn-primary btn-new-register btn-lg" %>
-	    </div>
+	    
+	    	<div class="col-xs-2" style="padding-bottom: 100px;padding-left: 1000px;">
+	    		<%= f.submit '新規登録', class: "btn btn-primary btn-new-register btn-lg" %>
+	    	</div>
 	    <% end %>
 	</div>
 </div>

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -1,26 +1,38 @@
 <div class="row">
-
-	<div class="col-sm-3">
-		<h4>ジャンル検索</h4>
-		<% @genres.each do |genre| %>
-			<%= link_to genre_path(genre) do %>
-				<p><%= genre.name %></p>
-			<% end %>
-		<% end %>
+	<div style="width: auto;height: 130px;">
+    </div>
+	<div class="col-sm-3" style="height: 800px;">
+		<div style="width: 250px;height:400px;background-color: rgba( 135, 135, 135, 0.55 );border-radius: 15px;">
+        	<div style="text-align: center;font-size: 23px;margin-top: 20px;padding-top: 19px;font-weight:bold;">ジャンル検索</div>
+          	<div style="margin-left: 30px;margin-top: 30px;">
+				<% @genres.each do |genre| %>
+					<%= link_to genre_path(genre) do %>
+						<p><%= genre.name %></p>
+					<% end %>
+				<% end %>
+			</div>
+		</div>
 	</div>
 
 	<div class="col-sm-9">
-		<h3><%= @genre.name %>一覧<span>(全<%= @product.count %>件)</span></h3>
-		<% @products.each do |product| %>
-			<%= link_to product_path(product) do %>
-				<%= attachment_image_tag product, :image, :fill, 160, 120, format: 'png',fallback: "no_image.png",size:'160x120' %>
-				<p><%= product.name %></p>
-				<p>¥<%= product.syouhizei(product.price) %></p>
-			<% end %>
-		<% end %>
-		<%= paginate @products %>
+		<div style="width: 950px;height: 600px;background-color: rgba( 135, 135, 135, 0.55 );border-radius: 15px;margin-top: 20px;padding-top: 1px;padding-left: 25px;">
+			<div style="font-weight:bold;font-size: 23px;margin-top: 16px;"><%= @genre.name %>一覧<span>(全<%= @product.count %>件)</span></div>
+
+			<div style=" display: flex; flex-wrap: wrap; align-content: center;">
+				<% @products.each do |product| %>
+					<div style=" margin:10px;">
+						<%= link_to product_path(product) do %>
+							<%= attachment_image_tag product, :image, :fill, 200, 150, format: 'png',fallback: "no_image.png",size:'200x150' %>
+							<p><%= product.name %></p>
+							<p>¥<%= product.syouhizei(product.price) %></p>
+						<% end %>
+					</div>
+				<% end %>
+			</div>
+
+			<%= paginate @products %>
+		</div>
 	</div>
-		
 </div>
 
 

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -13,7 +13,7 @@
 		<h3><%= @genre.name %>一覧<span>(全<%= @product.count %>件)</span></h3>
 		<% @products.each do |product| %>
 			<%= link_to product_path(product) do %>
-				<%= attachment_image_tag product, :image_id, :fill, 40, 30, format: 'png',fallback: "no_image.png" %>
+				<%= attachment_image_tag product, :image, :fill, 160, 120, format: 'png',fallback: "no_image.png",size:'160x120' %>
 				<p><%= product.name %></p>
 				<p>¥<%= product.syouhizei(product.price) %></p>
 			<% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -17,14 +17,19 @@
 	<div class="col-sm-9">
 	  <div style="width: 950px;height: 600px;background-color: rgba( 135, 135, 135, 0.55 );border-radius: 15px;margin-top: 20px;padding-top: 1px;padding-left: 25px;">
 		<div style="font-weight:bold;font-size: 23px;margin-top: 16px;">商品一覧<span>(全<%= @product.count %>件)</span></div>
-		<% @products.each do |product| %>
-			<%= link_to product_path(product) do %>
-				<%= attachment_image_tag product, :image, :fill, 160, 120, format: 'png',fallback: "no_image.png",size:'160x120' %>
-				<p><%= product.name %></p>
-				<p>¥<%= product.syouhizei(product.price) %></p>
-			<% end %>
 
-		<% end %>
+		<div style=" display: flex; flex-wrap: wrap; align-content: center;">
+			<% @products.each do |product| %>
+				<div style=" margin:10px;">
+					<%= link_to product_path(product) do %>
+						<%= attachment_image_tag product, :image, :fill, 200, 150, format: 'png',fallback: "no_image.png",size:'200x150' %>
+						<p><%= product.name %></p>
+						<p>¥<%= product.syouhizei(product.price) %></p>
+					<% end %>
+				</div>
+			<% end %>
+		</div>
+
 		<%= paginate @products %>
 	  </div>
 	</div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -19,7 +19,7 @@
 		<div style="font-weight:bold;font-size: 23px;margin-top: 16px;">商品一覧<span>(全<%= @product.count %>件)</span></div>
 		<% @products.each do |product| %>
 			<%= link_to product_path(product) do %>
-				<%= attachment_image_tag product, :image_id, :fill, 160, 120, format: 'png',fallback: "no_image.png",size:'160x120' %>
+				<%= attachment_image_tag product, :image, :fill, 160, 120, format: 'png',fallback: "no_image.png",size:'160x120' %>
 				<p><%= product.name %></p>
 				<p>¥<%= product.syouhizei(product.price) %></p>
 			<% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -8,7 +8,7 @@
 		<% end %>
 	</div>
 	<div class="col-sm-9">
-		<%= attachment_image_tag @product, :image_id, :fill, 320, 240, format: 'png',fallback: "no_image.png",size:'320x240' %>
+		<%= attachment_image_tag @product, :image, :fill, 320, 240, format: 'png',fallback: "no_image.png",size:'320x240' %>
 		<h3><%= @product.name %></h3>
 		<p><%= @product.introduction %></p>
 		<h4>¥<%= @product.syouhizei(@product.price) %><span>（税込）</span>


### PR DESCRIPTION
会員サイト／商品一覧・ジャンル一覧で、有効ジャンル・販売中商品のみ表示されるように修正。
会員サイト／商品一覧・ジャンル一覧・商品詳細viewのエラーを修正。（:image_id => :image)
        　　　　ジャンル一覧のcssを商品一覧と合わせました。また商品画像も横に並べてみました、、！
管理者サイト／商品新規登録画面修正しました！

確認お願いいたします！


